### PR TITLE
Add DPIA Formulier link to privacy principle page

### DIFF
--- a/docs/principes/privacy/index.md
+++ b/docs/principes/privacy/index.md
@@ -22,6 +22,12 @@ Privacy is een fundamenteel recht dat vanaf het begin moet worden ingebouwd in d
             <a href="https://www.autoriteitpersoonsgegevens.nl/nl/onderwerpen/avg-europese-privacywetgeving/data-protection-impact-assessment-dpia" class="action-button" target="_blank">Downloaden</a>
         </div>
         <div class="action-card">
+            <span class="wip-badge wip-badge-beschikbaar">beschikbaar</span>
+            <h4 >DPIA Formulier</h4>
+            <p >Online formulier voor gegevensbeschermingseffectbeoordeling</p>
+            <a href="https://minbzk.github.io/par-dpia-form/" class="action-button" target="_blank">Starten</a>
+        </div>
+        <div class="action-card">
             <span class="wip-badge wip-badge-ontwikkeling">ontwikkeling</span>
             <h4 >NICPET Tools</h4>
             <p >Privacy-bevorderende technologieën</p>


### PR DESCRIPTION
## Summary
- Added the Par-DPIA-Form tool as a new "direct aan de slag" tile in the privacy principle section
- Provides users with access to the online DPIA form for creating data protection impact assessments

## Test plan
- Check that the new DPIA Formulier tile appears correctly in the privacy principle page
- Verify that the link to https://minbzk.github.io/par-dpia-form/ works properly and opens in a new tab
- Ensure appropriate styling is maintained for the action cards section

🤖 Generated with [Claude Code](https://claude.ai/code)