### PR TITLE
Add Developer Overheid API's to open standards

### DIFF
--- a/docs/principes/open-standaarden/index.md
+++ b/docs/principes/open-standaarden/index.md
@@ -28,6 +28,12 @@ Open standaarden zijn gemeenschappelijke regels die gebruikers in staat stellen 
             <a href="https://docs.geostandaarden.nl/api/API-Strategie/" class="action-button" target="_blank">Bekijken</a>
         </div>
         <div class="action-card">
+            <span class="wip-badge wip-badge-beschikbaar">beschikbaar</span>
+            <h4 >Developer Overheid API's</h4>
+            <p >Overzicht van overheids-API's</p>
+            <a href="https://apis.developer.overheid.nl/apis" class="action-button" target="_blank">Ontdekken</a>
+        </div>
+        <div class="action-card">
             <span class="wip-badge wip-badge-ontwikkeling">ontwikkeling</span>
             <h4 >Standaardenregister</h4>
             <p >Centrale standaardendatabase</p>


### PR DESCRIPTION
## Summary
- Add Developer Overheid API's action card to open standards "Direct aan de slag" section
- Provides users with quick access to government APIs overview at apis.developer.overheid.nl

## Test plan
- [ ] Verify Developer Overheid API's link works correctly
- [ ] Check that new action card displays properly between API Standards and Standards Register
- [ ] Confirm the card follows existing design patterns

🤖 Generated with [Claude Code](https://claude.ai/code)