### PR TITLE
Fix deployment gh-pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,6 @@ on:
       - main
     tags:
       - '*'
-  pull_request:
-    branches:
-      - main
 
 jobs:
   deploy-main:


### PR DESCRIPTION
## Beschrijf jouw aanpassingen

Probleem gevonden: main.yml had een pull_request trigger die conflicteerde met preview.yml. Beide workflows runnen tegelijk voor PR's, waardoor soms je PR naar de main site ging in plaats van preview.
Oplossing: Verwijder de pull_request sectie uit main.yml zodat alleen preview.yml PR's afhandelt.

## Bij welk issue hoort deze pull-request?

## Checklist before requesting a review

- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/NeRDS/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd.
- [x] Ik heb mijn aanpassingen gecheckt op spelfouten.
- [x] Als ik gebruik heb gemaakt van links, dan heb ik gecheckt of deze werken.
- [x] Ik heb gebruik gemaakt van de templates en formats van de Nederlandse Richtlijn Digitale Systemen.
