### PR TITLE
chore: change WCAG-EM Report Tool link

### DIFF
--- a/docs/richtlijnen/toegankelijkheid/index.md
+++ b/docs/richtlijnen/toegankelijkheid/index.md
@@ -50,9 +50,9 @@ Meer informatie over de toegankelijkheidsverklaring van de NeRDS website is te v
         </div>
         <div class="action-card">
             <span class="wip-badge wip-badge-beschikbaar">beschikbaar</span>
-            <h4 >WCAG-EM Reporter</h4>
+            <h4 >WCAG-EM Report Tool</h4>
             <p >Tool voor het maken van toegankelijkheidsrapporten</p>
-            <a href="https://gitlab.com/digilab.overheid.nl/ecosystem/wcag-em-reporter" class="action-button" target="_blank">Gebruiken</a>
+            <a href="https://www.w3.org/WAI/eval/report-tool/" class="action-button" target="_blank">Gebruiken</a>
         </div>
         <div class="action-card">
             <span class="wip-badge wip-badge-ontwikkeling">ontwikkeling</span>


### PR DESCRIPTION
## Beschrijf jouw aanpassingen

Aanpassing van een link op verzoek van de mensen van DigiToegankelijk. Reden: de gelinkte tool is nog te veel proof of concept en er is niet goed gedocumenteerd wat de beperkingen ervan zijn. Deze PR verandert de link in een officiële tool van W3C.

## Bij welk issue hoort deze pull-request?

N.v.t.

## Checklist before requesting a review

- [x] Ik heb de [contributing guidelines](https://github.com/MinBZK/NeRDS/blob/main/CONTRIBUTING.md) van deze repository gelezen en gevolgd.
- [x] Ik heb mijn aanpassingen gecheckt op spelfouten.
- [x] Als ik gebruik heb gemaakt van links, dan heb ik gecheckt of deze werken.
- [x] Ik heb gebruik gemaakt van de templates en formats van de Nederlandse Richtlijn Digitale Systemen.
