### PR TITLE
fix: kort skill descriptions in om listing budget te ontlasten

### DIFF
--- a/skills/nerds-algoritmen/SKILL.md
+++ b/skills/nerds-algoritmen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nerds-algoritmen
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'algoritmen', 'AI', 'kunstmatige intelligentie', 'AI-verordening', 'AI Act', 'algoritmeregister', 'bias', 'discriminatie door AI', 'transparantie algoritmen', 'uitlegbaarheid', 'menselijk toezicht', 'IAMA', 'impact assessment', of advies wil over verantwoord gebruik van algoritmen bij de overheid."
+description: "Verantwoord gebruik van algoritmen en AI bij de overheid: AI-verordening (AI Act), algoritmeregister, IAMA, bias, uitlegbaarheid, menselijk toezicht."
 metadata:
   created-with-ai: "true"
   created-with-model: claude-opus-4-20250514

--- a/skills/nerds-cloud/SKILL.md
+++ b/skills/nerds-cloud/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nerds-cloud
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'cloud', 'cloudstrategie', 'soevereine cloud', 'digitale soevereiniteit', 'cloud-native', 'Infrastructure as Code', 'IaC', 'FinOps', 'multi-cloud', 'hybride cloud', 'SRE', 'Kubernetes', 'exit-strategie cloud', 'cloud overheid', of advies wil over cloudoplossingen bij de overheid."
+description: "Cloud bij de overheid: cloudstrategie, soevereine cloud, IaC, FinOps, multi-cloud, hybride cloud, SRE, Kubernetes, exit-strategie."
 metadata:
   created-with-ai: "true"
   created-with-model: claude-opus-4-20250514

--- a/skills/nerds-data/SKILL.md
+++ b/skills/nerds-data/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nerds-data
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'data', 'datamanagement', 'datakwaliteit', 'open data', 'datagedreven', 'data governance', 'metadata', 'datadeling', 'data bij de bron', of advies wil over het effectief gebruiken van data bij de overheid."
+description: "Datamanagement bij de overheid: datakwaliteit, data governance, open data, datadeling, metadata, data bij de bron, datagedreven werken."
 metadata:
   created-with-ai: "true"
   created-with-model: claude-opus-4-20250514

--- a/skills/nerds-duurzaamheid/SKILL.md
+++ b/skills/nerds-duurzaamheid/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nerds-duurzaamheid
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'duurzaamheid', 'green IT', 'green coding', 'energieverbruik ICT', 'CO2 footprint', 'circulair', 'MVI', 'maatschappelijk verantwoord inkopen', 'duurzame hosting', 'groene datacenters', of advies wil over het verduurzamen van technologie bij de overheid."
+description: "Duurzame ICT bij de overheid: green IT, green coding, energieverbruik, CO2-footprint, circulair, MVI (maatschappelijk verantwoord inkopen), groene datacenters."
 metadata:
   created-with-ai: "true"
   created-with-model: claude-opus-4-20250514

--- a/skills/nerds-gebruikers/SKILL.md
+++ b/skills/nerds-gebruikers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nerds-gebruikers
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'gebruikersbehoeften', 'user needs', 'gebruikersonderzoek', 'user research', 'gebruikersgericht ontwerpen', 'persona', 'klantreis', 'customer journey', 'UX onderzoek', 'gebruikercentraal', of advies wil over het vaststellen van gebruikersbehoeften bij digitale overheidssystemen."
+description: "Gebruikersbehoeften en -onderzoek bij digitale overheidssystemen: user research, persona's, klantreis (customer journey), gebruikergericht ontwerpen."
 metadata:
   created-with-ai: "true"
   created-with-model: claude-opus-4-20250514

--- a/skills/nerds-inkoop/SKILL.md
+++ b/skills/nerds-inkoop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nerds-inkoop
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'inkoop', 'aanbesteding', 'inkoopstrategie', 'vendor lock-in', 'leveranciersselectie', 'PIANOo', 'total cost of ownership', 'TCO', 'marktconsultatie', 'aanbestedingsregels', of advies wil over het inkopen van technologie bij de overheid."
+description: "Inkoop van technologie bij de overheid: aanbesteding, inkoopstrategie, vendor lock-in, leveranciersselectie, PIANOo, TCO, marktconsultatie."
 metadata:
   created-with-ai: "true"
   created-with-model: claude-opus-4-20250514

--- a/skills/nerds-integratie/SKILL.md
+++ b/skills/nerds-integratie/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nerds-integratie
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'integratie', 'systeemintegratie', 'legacy', 'API integratie', 'middleware', 'microservices', 'Digikoppeling', 'FSC', 'Common Ground', 'Haven', 'koppelvlak', 'ESB', of advies wil over het integreren van technologie bij de overheid."
+description: "Systeemintegratie bij de overheid: API's, middleware, microservices, legacy, Digikoppeling, FSC, Common Ground, Haven, koppelvlakken, ESB."
 metadata:
   created-with-ai: "true"
   created-with-model: claude-opus-4-20250514

--- a/skills/nerds-opensource/SKILL.md
+++ b/skills/nerds-opensource/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nerds-opensource
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'open source', 'EUPL', 'publieke code', 'open-tenzij', 'publieke repository', 'open source licentie', 'CONTRIBUTING.md', 'Code of Conduct', 'secrets management', 'transparant werken', 'code publiceren', of advies wil over open source werken bij de overheid."
+description: "Open source werken bij de overheid: EUPL, publieke code, open-tenzij, licenties, CONTRIBUTING.md, Code of Conduct, secrets management."
 metadata:
   created-with-ai: "true"
   created-with-model: claude-opus-4-20250514

--- a/skills/nerds-privacy/SKILL.md
+++ b/skills/nerds-privacy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nerds-privacy
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'privacy', 'AVG', 'GDPR', 'DPIA', 'gegevensbescherming', 'persoonsgegevens', 'privacy by design', 'dataminimalisatie', 'verwerkingsregister', 'datalekken', 'Autoriteit Persoonsgegevens', of advies wil over privacy bij digitale overheidssystemen."
+description: "Privacy bij de overheid: AVG/GDPR, DPIA, persoonsgegevens, privacy by design, dataminimalisatie, verwerkingsregister, datalekken, Autoriteit Persoonsgegevens."
 metadata:
   created-with-ai: "true"
   created-with-model: claude-opus-4-20250514

--- a/skills/nerds-samenwerking/SKILL.md
+++ b/skills/nerds-samenwerking/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nerds-samenwerking
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'samenwerking', 'hergebruik', 'delen', 'kennisdeling', 'Common Ground', 'dubbel werk voorkomen', 'componenten hergebruiken', of advies wil over samenwerken en hergebruiken bij digitale overheidssystemen."
+description: "Samenwerken en hergebruiken bij de overheid: kennisdeling, componenten hergebruiken, Common Ground, dubbel werk voorkomen."
 metadata:
   created-with-ai: "true"
   created-with-model: claude-opus-4-20250514

--- a/skills/nerds-standaarden/SKILL.md
+++ b/skills/nerds-standaarden/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nerds-standaarden
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'open standaarden', 'interoperabiliteit', 'Forum Standaardisatie', 'pas-toe-of-leg-uit', 'vendor lock-in', 'standaardisatie', of advies wil over het gebruik van open standaarden bij digitale overheidssystemen."
+description: "Open standaarden bij de overheid: Forum Standaardisatie, pas-toe-of-leg-uit, interoperabiliteit, voorkómen van vendor lock-in."
 metadata:
   created-with-ai: "true"
   created-with-model: claude-opus-4-20250514

--- a/skills/nerds-toegankelijkheid/SKILL.md
+++ b/skills/nerds-toegankelijkheid/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nerds-toegankelijkheid
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'toegankelijkheid', 'inclusie', 'WCAG', 'a11y', 'accessibility', 'screenreader', 'toetsenbordnavigatie', 'kleurcontrast', 'EN 301 549', 'digitoegankelijk', 'NL Design System', 'alt tekst', 'inclusief ontwerpen', of advies wil over het toegankelijk maken van digitale overheidssystemen."
+description: "Digitale toegankelijkheid bij de overheid: WCAG, a11y, EN 301 549, screenreader, toetsenbordnavigatie, kleurcontrast, NL Design System, inclusief ontwerpen."
 metadata:
   created-with-ai: "true"
   created-with-model: claude-opus-4-20250514

--- a/skills/nerds-veiligheid/SKILL.md
+++ b/skills/nerds-veiligheid/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nerds-veiligheid
-description: "Gebruik deze skill wanneer de gebruiker vraagt over 'beveiliging', 'security', 'informatiebeveiliging', 'cybersecurity', 'BIO', 'Baseline Informatiebeveiliging', 'penetratietest', 'vulnerability', 'kwetsbaarheid', 'versleuteling', 'encryption', 'beveiligingsincident', of advies wil over het beveiligen van digitale overheidssystemen."
+description: "Informatiebeveiliging bij de overheid: BIO (Baseline Informatiebeveiliging), penetratietesten, kwetsbaarheden, versleuteling, beveiligingsincidenten."
 metadata:
   created-with-ai: "true"
   created-with-model: claude-opus-4-20250514

--- a/skills/nerds/SKILL.md
+++ b/skills/nerds/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nerds
-description: "Overzicht van de Nederlandse Richtlijn Digitale Systemen (NeRDS). Gebruik deze skill wanneer de gebruiker vraagt over 'NeRDS', 'Nederlandse Richtlijn Digitale Systemen', 'richtlijnen digitale systemen', 'welke richtlijnen zijn er', 'richtlijnen overzicht', 'digitale overheid richtlijnen', of een vraag heeft die niet duidelijk bij een specifieke richtlijn past."
+description: "Nederlandse Richtlijn Digitale Systemen (NeRDS): 13 richtlijnen voor ontwerpen, ontwikkelen en inkopen van digitale overheidssystemen."
 metadata:
   created-with-ai: "true"
   created-with-model: claude-opus-4-20250514


### PR DESCRIPTION
## Probleem

Per `developer-overheid-nl/skills-marketplace#61` melden gebruikers dat de plugin descriptions in de Nederlandse-overheid skills-ecosystemen zoveel skill listing budget vreten dat in gemengde Claude Code sessies skills uit de listing vallen ("60 descriptions dropped, 3.1%/1% of context"). De `nerds`-plugin werd in dat issue specifiek genoemd (14 skills, ~4 300 chars).

Onze 14 skills gingen tot 362 chars (`nerds`), gemiddeld 307 chars. Het patroon was vrijwel altijd `Gebruik deze skill wanneer de gebruiker vraagt over 'X', 'Y', 'Z', ...` met 8-15 quoted keywords. Die aanhef en quotes voegen geen triggerwaarde toe — het model matcht semantisch op de termen, niet op de aanhalingstekens of de "Gebruik deze skill" formule.

## Wat verandert

Per skill: één Nederlandse functionele zin met de eigennamen die mensen daadwerkelijk gebruiken. Doel ~150 chars, max 200.

Niet-afleidbare jargon blijft expliciet:
- nerds-algoritmen: AI Act, algoritmeregister, IAMA
- nerds-cloud: IaC, FinOps, SRE, Kubernetes
- nerds-duurzaamheid: MVI (maatschappelijk verantwoord inkopen)
- nerds-inkoop: PIANOo, TCO
- nerds-integratie: Digikoppeling, FSC, Common Ground, Haven, ESB
- nerds-opensource: EUPL, CONTRIBUTING.md, Code of Conduct
- nerds-privacy: AVG/GDPR, DPIA, Autoriteit Persoonsgegevens
- nerds-toegankelijkheid: WCAG, a11y, EN 301 549, NL Design System
- nerds-veiligheid: BIO (Baseline Informatiebeveiliging)

Synoniemen die het model semantisch dekt zijn weg: 'AI' + 'kunstmatige intelligentie' werd één keer "algoritmen en AI". 'AVG' + 'GDPR' werd "AVG/GDPR". 'security' + 'cybersecurity' + 'informatiebeveiliging' werd "Informatiebeveiliging".

## Resultaat

| Skill | Was | Nu |
|---|---:|---:|
| nerds | 362 | 134 |
| nerds-algoritmen | 350 | 149 |
| nerds-cloud | 332 | 130 |
| nerds-data | 257 | 135 |
| nerds-duurzaamheid | 305 | 159 |
| nerds-gebruikers | 331 | 149 |
| nerds-inkoop | 289 | 139 |
| nerds-integratie | 283 | 138 |
| nerds-opensource | 309 | 134 |
| nerds-privacy | 297 | 158 |
| nerds-samenwerking | 255 | 122 |
| nerds-standaarden | 261 | 126 |
| nerds-toegankelijkheid | 337 | 156 |
| nerds-veiligheid | 334 | 149 |
| **Totaal** | **4 302** | **1 978** |

Reductie: -54%.

Refs developer-overheid-nl/skills-marketplace#61