### PR TITLE
chore: bump version to 0.1.2 voor description-fix

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "nerds",
   "description": "Plugin voor de Nederlandse Richtlijn Digitale Systemen (NeRDS). Bevat skills voor 13 richtlijnen die richting geven aan het ontwerpen, ontwikkelen en inkopen van digitale systemen binnen de Nederlandse overheid: gebruikersbehoeften, toegankelijkheid, open source, open standaarden, cloud, veiligheid, privacy, samenwerking, integratie, data, algoritmen, inkoop en duurzaamheid.",
-  "version": "0.1.1"
+  "version": "0.1.2"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,5 +2,5 @@
   "name": "nerds",
   "displayName": "Nerds",
   "description": "Plugin voor de Nederlandse Richtlijn Digitale Systemen (NeRDS). Bevat skills voor 13 richtlijnen die richting geven aan het ontwerpen, ontwikkelen en inkopen van digitale systemen binnen de Nederlandse overheid: gebruikersbehoeften, toegankelijkheid, open source, open standaarden, cloud, veiligheid, privacy, samenwerking, integratie, data, algoritmen, inkoop en duurzaamheid.",
-  "version": "0.1.1"
+  "version": "0.1.2"
 }

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "nerds",
   "description": "Plugin voor de Nederlandse Richtlijn Digitale Systemen (NeRDS). Bevat skills voor 13 richtlijnen die richting geven aan het ontwerpen, ontwikkelen en inkopen van digitale systemen binnen de Nederlandse overheid: gebruikersbehoeften, toegankelijkheid, open source, open standaarden, cloud, veiligheid, privacy, samenwerking, integratie, data, algoritmen, inkoop en duurzaamheid.",
-  "version": "0.1.1"
+  "version": "0.1.2"
 }


### PR DESCRIPTION
Volgt op #257: bumpt plugin.json versie van 0.1.1 naar 0.1.2 zodat de marketplace de korte descriptions oppikt.